### PR TITLE
Update .env - fix wrong environment variable name

### DIFF
--- a/Labfiles/02-ai-services-security/Python/keyvault-client/.env
+++ b/Labfiles/02-ai-services-security/Python/keyvault-client/.env
@@ -1,4 +1,4 @@
-COG_SERVICE_ENDPOINT=your_cognitive_services_endpoint
+AI_SERVICE_ENDPOINT=your_AI_services_endpoint
 KEY_VAULT=your_key_vault_name
 TENANT_ID=your_service_principal_tenant_id
 APP_ID=your_service_principal_app_id


### PR DESCRIPTION
The Python code snippet tries to read AI_SERVICE_ENDPOINT, not COG_SERVICE_ENDPOINT. The previous exercises used AI_SERVICE_ENDPOINT as well, so I assume that's what this one should use.