### PR TITLE
Update rest-test.cmd

### DIFF
--- a/Labfiles/02-ai-services-security/rest-test.cmd
+++ b/Labfiles/02-ai-services-security/rest-test.cmd
@@ -1,1 +1,1 @@
-curl -X POST "<your-endpoint>/language/:analyze-text?api-version=2023-04-01" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: <your-key>" --data-ascii "{'analysisInput':{'documents':[{'id':1,'text':'hello'}]}, 'kind': 'LanguageDetection'}"
+curl -X POST "<your-endpoint>/language/:analyze-text?api-version=2023-11-15-preview" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: <your-key>" --data-ascii "{'analysisInput':{'documents':[{'id':1,'text':'hello'}]}, 'kind': 'LanguageDetection'}"


### PR DESCRIPTION
the previous call was working only when using single service. the only way I got to make this work for multiservice was to update the URL suffix to comply with doc:https://learn.microsoft.com/en-us/azure/ai-services/language-service/language-detection/quickstart?tabs=linux&pivots=rest-api#code-example